### PR TITLE
SwipeRefreshLayout fix, and animation update

### DIFF
--- a/covert/src/main/java/nz/co/trademe/covert/canvas/CanvasUtils.kt
+++ b/covert/src/main/java/nz/co/trademe/covert/canvas/CanvasUtils.kt
@@ -51,7 +51,12 @@ internal fun Canvas.drawDrawable(
         centerCoordinate: Coordinate,
         drawable: Drawable,
         @ColorInt colorInt: Int,
-        @Px iconSizePx: Int) {
+        @Px iconSizePx: Int,
+        circularClipRadius: Float?) {
+    if (circularClipRadius != null && circularClipRadius <= 0f) {
+        return
+    }
+
     val (centerX, centerY) = centerCoordinate
 
     val left = centerX - (0.5 * iconSizePx)
@@ -68,6 +73,9 @@ internal fun Canvas.drawDrawable(
 
     save()
     translate(0F, canvasY)
+    if (circularClipRadius != null) {
+        clipPath(Path().apply { addCircle(centerX, centerY, circularClipRadius, Path.Direction.CCW) })
+    }
     drawable.setColorFilter(colorInt, PorterDuff.Mode.SRC_IN)
     drawable.draw(this)
     restore()

--- a/covert/src/main/java/nz/co/trademe/covert/canvas/IconChangeColorCanvasDrawable.kt
+++ b/covert/src/main/java/nz/co/trademe/covert/canvas/IconChangeColorCanvasDrawable.kt
@@ -56,7 +56,8 @@ internal class IconChangeColorCanvasDrawable(
                 ),
                 drawable = icon,
                 colorInt = currentIconColor,
-                iconSizePx = iconSizePx)
+                iconSizePx = iconSizePx,
+                circularClipRadius = null)
     }
 
     private fun createColorInterpolationAnimator() = ValueAnimator().apply {


### PR DESCRIPTION
* For recyclerviews that are contained with a SwipeRefreshLayout, currently swiping is cancelled if your finger moves down slightly, due to the pull-to-refresh gesture still being active. This can now be disabled while swiping.
* When swiping a non-watchlisted listing, the icon changes colour abruptly, which looks bad. I've updated it so that the colour always matches the background.